### PR TITLE
Fix GitHub Actions release workflow to handle existing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,37 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      upload_url: ${{ steps.check_release.outputs.release_exists == 'true' && steps.check_release.outputs.upload_url || steps.create_release.outputs.upload_url }}
       version: ${{ steps.get_version.outputs.version }}
     steps:
       - name: Get version from tag
         id: get_version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
+      - name: Check if release exists
+        id: check_release
+        run: |
+          RELEASE_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}" | \
+            jq -r '.id // ""')
+          
+          if [ -n "$RELEASE_ID" ] && [ "$RELEASE_ID" != "null" ]; then
+            echo "Release already exists for tag ${{ github.ref_name }}"
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+            echo "release_id=$RELEASE_ID" >> $GITHUB_OUTPUT
+            # Get upload URL for existing release
+            UPLOAD_URL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID" | \
+              jq -r '.upload_url')
+            echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
+          else
+            echo "No release exists for tag ${{ github.ref_name }}"
+            echo "release_exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create Release
         id: create_release
+        if: steps.check_release.outputs.release_exists != 'true'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,6 +54,8 @@ jobs:
 
   build:
     needs: create-release
+    # Run even if the create-release job skipped creating a new release
+    if: always()
     name: Build and Release
     runs-on: ${{ matrix.os }}
     strategy:
@@ -104,6 +128,8 @@ jobs:
 
   create-installers:
     needs: create-release
+    # Run even if the create-release job skipped creating a new release
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem
The GitHub Actions release workflow was failing when trying to create a release for a tag that already had a release associated with it.

## Solution
- Added a check for existing releases before attempting to create a new one
- Updated upload_url reference to work with both new and existing releases
- Ensured build and installer jobs run even if release already exists

## Changes
- Modified .github/workflows/release.yml to handle the case where a release already exists for a tag
- Added conditional logic to skip release creation if it already exists
- Ensured downstream jobs continue to run regardless of release creation status

This fix will allow the workflow to successfully build and upload artifacts to existing releases.