### PR TITLE
Fix version and GLIBC compatibility issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
               "Linux x86_64")
                   PLATFORM="linux"
                   ARCH="amd64"
-                  FILE="gather_files-linux-amd64"
+                  FILE="gather_files-linux-musl-amd64"
                   ;;
               "Linux aarch64")
                   PLATFORM="linux"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v0.2.6] - 2025-03-06
+
+### Fixed
+- GLIBC互換性問題の修正
+  - Linuxバイナリを MUSLベースに変更し、幅広い互換性を確保
+  - WSL環境を含む様々なLinuxディストリビューションでの動作を改善
+- バージョン表示の修正
+  - CLIバージョン表示をCargo.tomlから自動取得するように変更
+  - バージョン番号のハードコードを排除
+
+[v0.2.6]: https://github.com/herring101/gather_files/compare/v0.2.5...v0.2.6
+
 ## [v0.2.5] - 2025-03-06
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gather_files"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 description = "Gather project files for LLM processing"
 authors = ["herring101"]

--- a/src/args.rs
+++ b/src/args.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 /// CLIオプションを clap でパース
 pub fn parse_args() -> CLIOptions {
     let matches = Command::new("gather_files")
-        .version("0.2.4")
+        .version(env!("CARGO_PKG_VERSION"))
         .author("herring101")
         .about("Collect files recursively and output them as text for LLM processing.")
         .arg(


### PR DESCRIPTION
## 問題
- CLIのバージョン表示がハードコードされており、Cargo.tomlと一致していない
- WSLなど一部のLinux環境でGLIBC互換性の問題が発生している

## 修正内容
- バージョンを0.2.6に更新
- args.rsでenv!("CARGO_PKG_VERSION")を使用して自動的にバージョンを取得するよう変更
- デフォルトのLinuxバイナリをMUSLベースに変更して互換性を向上
- CHANGELOG.mdにv0.2.6の詳細を追加

## テスト
- cargo fmt とcargo clippyを実行済み
- バージョン表示が正しく動作することを確認

この修正により、WSLを含む様々なLinux環境での互換性が向上します。