### PR TITLE
Fix: Update install.sh to use MUSL binary for Linux x86_64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ case "$(uname -sm)" in
     "Linux x86_64")
         PLATFORM="linux"
         ARCH="amd64"
-        FILE="gather_files-linux-amd64"
+        FILE="gather_files-linux-musl-amd64"
         ;;
     "Linux aarch64")
         PLATFORM="linux"


### PR DESCRIPTION
このPRでは、Linux x86_64環境用のインストールスクリプトを修正し、MUSL対応バイナリを使用するようにしています。これにより、WSLを含む様々なLinux環境でのGLIBC互換性の問題が解決されます。